### PR TITLE
Update whac.js

### DIFF
--- a/whac_online/whac.js
+++ b/whac_online/whac.js
@@ -755,12 +755,13 @@ function recomposeArmy() {
 		});
 	}
 
-	calculateCompendium();
-
+	// Calculate tier bonuses before the Compendium
 	if (currentTier) {
 		computeTiersLevel();
 		computeTiersBonus();
 	}
+
+	calculateCompendium();
 
 	for (var i = 0; i < full_entries.groups.length; i++) {
 		var group = full_entries.groups[i];


### PR DESCRIPTION
Bug fix : calculate tier bonuses before the Compendium to fix a bug for T1 bonuses changing unit costs.
Test case : Add a Cephalyx Mind Slaver unit to a Denegha2 - Body & Soul tier list.
